### PR TITLE
Fix undefined variable `env`

### DIFF
--- a/Raven/Client.php
+++ b/Raven/Client.php
@@ -26,7 +26,7 @@ class Client extends Raven_Client
             }
             else
             {
-                include $root . '/../app/etc/env.php';;
+                $env = include $root . '/../app/etc/env.php';;
             }
 
             $isDeveloper = array_key_exists('MAGE_MODE', $env) && $env[ 'MAGE_MODE' ] === 'developer';


### PR DESCRIPTION
The `Client.php` file causes an exception in case Magento is served from the `pub` folder. This PR fixes it.

Thank you for the great module!